### PR TITLE
Handle expired or revoked tokens by calling $adapter->logout()

### DIFF
--- a/src/Auth/HybridAuthAuthenticate.php
+++ b/src/Auth/HybridAuthAuthenticate.php
@@ -1,6 +1,7 @@
 <?php
 namespace ADmad\HybridAuth\Auth;
 
+use Cake\ORM\TableRegistry;
 use Cake\Auth\FormAuthenticate;
 use Cake\Controller\ComponentRegistry;
 use Cake\Core\Configure;
@@ -157,7 +158,13 @@ class HybridAuthAuthenticate extends FormAuthenticate {
  * @return array User record
  */
 	protected function _getUser($provider, $adapter) {
-		$providerProfile = $adapter->getUserProfile();
+		try {
+			$providerProfile = $adapter->getUserProfile();
+		} catch(\Exception $e) {
+			$adapter->logout();
+			throw $e;
+		}
+
 
 		$userModel = $this->_config['userModel'];
 		list(, $model) = pluginSplit($userModel);


### PR DESCRIPTION
Hi there,

I bumped into an issue where, if the user revoked the application's access, I'd get stuck in a loop on the login page since HybridAuth attempted to fetch the profile with the old credentials over and over again.

This commit addresses the issue with a try/catch that, if an exception is encountered, calls `$adapter->logout();`. The actual exception is then passed upstream. I didn't check for any particular error codes, so feel free to extend further.

Cheers!
