### PR TITLE
Update `app::import()` to use path described in readme

### DIFF
--- a/Controller/Component/Auth/HybridAuthAuthenticate.php
+++ b/Controller/Component/Auth/HybridAuthAuthenticate.php
@@ -3,7 +3,7 @@ App::uses('CakeSession', 'Model/Datasource');
 App::uses('FormAuthenticate', 'Controller/Component/Auth');
 
 if (!class_exists('Hybrid_Auth')) {
-	App::import('Vendor', 'HybridAuth.hybridauth/Hybrid/Auth');
+	App::import('Vendor', 'hybridauth/Hybrid/Auth');
 }
 
 /**

--- a/Controller/HybridAuthController.php
+++ b/Controller/HybridAuthController.php
@@ -3,8 +3,8 @@ App::uses('AppController', 'Controller');
 App::uses('CakeSession', 'Model/Datasource');
 
 if (!class_exists('Hybrid_Auth')) {
-	App::import('Vendor', 'HybridAuth.hybridauth/Hybrid/Auth');
-	App::import('Vendor', 'HybridAuth.hybridauth/Hybrid/Endpoint');
+	App::import('Vendor', 'hybridauth/Hybrid/Auth');
+	App::import('Vendor', 'hybridauth/Hybrid/Endpoint');
 }
 
 /**


### PR DESCRIPTION
I tried installing CakePHP-HybridAuth on a fresh instance of Cake using the manual install instructions from the project readme, but the vendor classes are not being loaded.

`HybridAuth.hybridauth/Hybrid/Auth` doesn't seem to point to `app/Vendor/hybridauth/Hybrid/Auth`. Removing the dot notation prefix (`HybridAuth.`) fixes this. Composer installs are not affected.