### PR TITLE
Prevent prefix routing

### DIFF
--- a/src/Auth/HybridAuthAuthenticate.php
+++ b/src/Auth/HybridAuthAuthenticate.php
@@ -180,7 +180,8 @@ class HybridAuthAuthenticate extends BaseAuthenticate
             [
                 'plugin' => 'ADmad/HybridAuth',
                 'controller' => 'HybridAuth',
-                'action' => 'authenticated'
+                'action' => 'authenticated',
+                'prefix' => false
             ],
             true
         );

--- a/src/Auth/HybridAuthAuthenticate.php
+++ b/src/Auth/HybridAuthAuthenticate.php
@@ -90,7 +90,8 @@ class HybridAuthAuthenticate extends BaseAuthenticate
                 [
                     'plugin' => 'ADmad/HybridAuth',
                     'controller' => 'HybridAuth',
-                    'action' => 'endpoint'
+                    'action' => 'endpoint',
+                    'prefix' => false
                 ],
                 true
             );


### PR DESCRIPTION
Prevent the auth from getting trapped in prefix routing.

If you have Auth setup in a way which redirects users, such as accessing `example.com/admin/users`, which would redirect to the login, you'll get trapped inside the `admin` prefix. This will result in a fatal for a missing route, as the prefix is appended.

I was about to start writing a test for this and realised that it's a protected method. As such it's not 'strictly' testable as a part of the public api. Also I didn't feel that making an assumption about implementing a test with reflection on someone else's repository was a good idea.