### PR TITLE
Added some missing @throws tags

### DIFF
--- a/src/Auth/HybridAuthAuthenticate.php
+++ b/src/Auth/HybridAuthAuthenticate.php
@@ -233,6 +233,8 @@ class HybridAuthAuthenticate extends BaseAuthenticate
      *
      * @param \Hybrid_Provider_Model $adapter Hybrid auth adapter instance.
      * @return array User record
+     * @throws \Exception Thrown when a profile cannot be retrieved
+     * @throws \RuntimeException Thrown when the user has not created a listener, or the entity cannot be persisted
      */
     protected function _getUser($adapter)
     {


### PR DESCRIPTION
I'm not sure if you think these are needed, but PHP Storm kicked up a fuss about them missing, so figured I'd add them in.

It does pass `phpcs`, but if it's not to your taste, feel free to close the pr.