### PR TITLE
Updated composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "require": {
     "cakephp/cakephp": "~3.0",
-    "hybridauth/hybridauth": "2.4.*"
+    "hybridauth/hybridauth": "2.6.*"
   },
   "minimum-stability": "dev",
   "autoload": {


### PR DESCRIPTION
composer.json was updated in order to user a newer version of hybrid auth. Among the changes to hybrid auth is compatibility with the newer Facebook API. This was added in v2.5.0 but using 2.6.0 adds in a few more providers as well. 

Facebook fix is #525 shown in [changelog for 2.5](https://github.com/hybridauth/hybridauth/releases/tag/v2.5.0)