### PR TITLE
Update HybridAuthAuthenticate.php

### DIFF
--- a/src/Auth/HybridAuthAuthenticate.php
+++ b/src/Auth/HybridAuthAuthenticate.php
@@ -254,12 +254,12 @@ class HybridAuthAuthenticate extends BaseAuthenticate
 
         $user = null;
         $profile = $this->_query($providerProfile->identifier)->first();
-
+        $UsersTable = TableRegistry::get($config['userModel']);
+        
         if ($profile && !empty($profile->user)) {
             $user = $profile->user;
             $profile->unsetProperty('user');
         } elseif ($providerProfile->email) {
-            $UsersTable = TableRegistry::get($config['userModel']);
             $user = $UsersTable
                 ->find($config['finder'])
                 ->where([


### PR DESCRIPTION
This is what I had to do to avoid "Call to a member function primaryKey()" issue when I was trying to do social auth for twitter with config settings as below. 

'Twitter' => [
                'enabled' => true,
                'keys' => [
                    'key' => 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
                    'secret' => 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
                ],
                'includeEmail' => false // Only if your app is whitelisted by Twitter Support
            ]

But application gave me "Call to a member function primaryKey()" so after doing this proposed change I was able to do Authentication Properly.