### PR TITLE
Fix up redirect for CakePHP3.4+ as query string solution.

### DIFF
--- a/src/Auth/HybridAuthAuthenticate.php
+++ b/src/Auth/HybridAuthAuthenticate.php
@@ -121,7 +121,7 @@ class HybridAuthAuthenticate extends BaseAuthenticate
         if ($request->query(static::QUERY_STRING_REDIRECT)) {
             if (is_array($hybridConfig['base_url'])) {
                 $hybridConfig['base_url']['?'][static::QUERY_STRING_REDIRECT] = $request->query(static::QUERY_STRING_REDIRECT);
-            }  else {
+            } else {
                 $char = strpos($hybridConfig['base_url'], '?') === false ? '?' : '&';
                 $hybridConfig['base_url'] .= $char . static::QUERY_STRING_REDIRECT . '=' . urlencode($request->query(static::QUERY_STRING_REDIRECT));
             }

--- a/src/Auth/HybridAuthAuthenticate.php
+++ b/src/Auth/HybridAuthAuthenticate.php
@@ -118,14 +118,7 @@ class HybridAuthAuthenticate extends BaseAuthenticate
             ];
         }
 
-        if ($request->query(static::QUERY_STRING_REDIRECT)) {
-            if (is_array($hybridConfig['base_url'])) {
-                $hybridConfig['base_url']['?'][static::QUERY_STRING_REDIRECT] = $request->query(static::QUERY_STRING_REDIRECT);
-            } else {
-                $char = strpos($hybridConfig['base_url'], '?') === false ? '?' : '&';
-                $hybridConfig['base_url'] .= $char . static::QUERY_STRING_REDIRECT . '=' . urlencode($request->query(static::QUERY_STRING_REDIRECT));
-            }
-        }
+        $hybridConfig['base_url'] = $this->appendRedirectQueryString($hybridConfig['base_url'], $request->query(static::QUERY_STRING_REDIRECT));
 
         $hybridConfig['base_url'] = Router::url($hybridConfig['base_url'], true);
 
@@ -219,14 +212,7 @@ class HybridAuthAuthenticate extends BaseAuthenticate
             $returnTo = $this->config('hauth_return_to');
         }
 
-        if ($request->query(static::QUERY_STRING_REDIRECT)) {
-            if (is_array($returnTo)) {
-                $returnTo['?'][static::QUERY_STRING_REDIRECT] = $request->query(static::QUERY_STRING_REDIRECT);
-            } else {
-                $char = strpos($returnTo, '?') === false ? '?' : '&';
-                $returnTo .= $char . static::QUERY_STRING_REDIRECT . '=' . urlencode($request->query(static::QUERY_STRING_REDIRECT));
-            }
-        }
+        $returnTo = $this->appendRedirectQueryString($returnTo, $request->query(static::QUERY_STRING_REDIRECT));
 
         $returnTo = Router::url($returnTo, true);
 
@@ -444,5 +430,26 @@ class HybridAuthAuthenticate extends BaseAuthenticate
     public function implementedEvents()
     {
         return ['Auth.logout' => 'logout'];
+    }
+
+    /**
+     * @param string|array $url URL
+     * @param string $redirectQueryString Redirect query string
+     * @return string URL
+     */
+    protected function appendRedirectQueryString($url, $redirectQueryString)
+    {
+        if (!$redirectQueryString) {
+            return $url;
+        }
+
+        if (is_array($url)) {
+            $url['?'][static::QUERY_STRING_REDIRECT] = $redirectQueryString;
+        } else {
+            $char = strpos($url, '?') === false ? '?' : '&';
+            $url .= $char . static::QUERY_STRING_REDIRECT . '=' . urlencode($redirectQueryString);
+        }
+
+        return $url;
     }
 }


### PR DESCRIPTION
Resolves https://github.com/ADmad/CakePHP-HybridAuth/issues/76

Tested with a current application. Works :+1: 

Unfortunately, this plugin doesn't come with tests yet.
I recommend this to be released as a minor, as it could theoretically be a bit BC breaking with Router::url() defined URLs and a relative path setup (subfolder).

But this fixes the URL handling in general, as it will now properly work out of the box with query strings while supporting relativ string URLs.

There is some room for improvement, sure, but this should already suffice as a basic support way.