### PR TITLE
Add a login event for login counter and flash message for login success.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /phpunit.xml
 /vendor
+/.idea/

--- a/src/Controller/HybridAuthController.php
+++ b/src/Controller/HybridAuthController.php
@@ -50,7 +50,7 @@ class HybridAuthController extends AppController
         if ($user) {
             $this->Auth->setUser($user);
 
-            $this->dispatchEvent('HybridAuth.login', [$user]);
+            $this->dispatchEvent('HybridAuth.login', ['user' => $user]);
 
             return $this->redirect($this->Auth->redirectUrl());
         }

--- a/src/Controller/HybridAuthController.php
+++ b/src/Controller/HybridAuthController.php
@@ -50,6 +50,8 @@ class HybridAuthController extends AppController
         if ($user) {
             $this->Auth->setUser($user);
 
+            $this->dispatchEvent('HybridAuth.login', [$user]);
+
             return $this->redirect($this->Auth->redirectUrl());
         }
 


### PR DESCRIPTION
The normal login code is not fired/executed at all for hybrid auth login:

    /**
     * @return \Cake\Http\Response|null
     */
    public function login()
    {
        if ($this->request->is('post')) {
            $user = $this->Auth->identify();
            if ($user) {
                unset($user['password']);
                $this->Auth->setUser($user);
                $this->Users->loginUpdate($user);

                $this->Flash->success(__('You are now logged in'));
                return $this->redirect($this->Auth->redirectUrl());
            }
            $this->Flash->error(__('Login or password was not correct'));
        }
    }


As such no flash message for successful login or login counter update can happen right now.

This adds the missing event to be able to enable this (to sync with normal post form login).